### PR TITLE
Add J130 RustSBI report

### DIFF
--- a/reports/2024-10.md
+++ b/reports/2024-10.md
@@ -28,6 +28,143 @@ Monthly update of Jiachen Joint Open Source Internship Program
 
 ### J130 BL808 Rust支持库开发实习生【甲辰计划联合实习生培养】
 
+#### 裸机支持组(HAL组)
+
+团队成员直接做出的代码贡献如下。为bouffalo-hal和新成立的bouffaloader项目贡献以下代码，尤其是psram高速信号支持有显著的进展：
+
+- 为bl808添加psram支持，将读写错误率降低至0（[链接](https://github.com/rustsbi/bouffalo-hal/pull/2)）
+- 修复三个spi相关的例子（[链接](https://github.com/rustsbi/bouffalo-hal/pull/6)）
+- 为bouffalo-hal项目添加集成测试模块，[链接](https://github.com/rustsbi/bouffalo-hal/pull/3)
+- 为bouffalo-hal项目的uart-demo例子增加命令行embedded-cli支持并补充烧录教程，[链接1](https://github.com/rustsbi/bouffalo-hal/pull/4)，[链接2](https://github.com/rustsbi/bouffalo-hal/pull/5)
+- 发起bouffaloader项目，使用串口打印hello world，[链接](https://github.com/rustsbi/bouffaloader/commit/4d782399b9514ca83fa404742eb986fd135b7519)
+- 为bouffaloader添加cli-demo，[链接](https://github.com/rustsbi/bouffaloader/compare/main...NanaHigh:bouffaloader:nanahigh/cli)
+- 为bouffaloader添加代码烧录教程，[链接](https://github.com/rustsbi/bouffaloader/compare/main...NanaHigh:bouffaloader:nanahigh/cli)
+
+对allwinner-hal和allwinner-hal/rfel贡献以下修改，尤其是全志自研smhc外设的适配工作得到显著进展：
+
+- 为d1添加smhc外设与sd卡初始化的例子（[链接](https://github.com/rustsbi/allwinner-hal/pull/16)）
+- 为allwinner-hal的ccu和smhc添加测试（[链接1](https://github.com/rustsbi/allwinner-hal/pull/7)、[链接2](https://github.com/rustsbi/allwinner-hal/pull/6)和[链接3](https://github.com/rustsbi/allwinner-hal/pull/9)）
+- 在allwinner-hal的soc添加smhc外设并绑定管脚（[链接1](https://github.com/rustsbi/allwinner-hal/pull/11)、[链接2](https://github.com/rustsbi/allwinner-hal/pull/14)）；为allwinner-hal的smhc补充测试用例和函数，[链接](https://github.com/rustsbi/allwinner-hal/pull/13)；修订smhc模块的剩余文档，[链接](https://github.com/rustsbi/allwinner-hal/commit/a25cc70d04056979988a51bb530a3d2be7ceebeb)；增加smhc模块的初步架构，[链接1](https://github.com/rustsbi/allwinner-hal/commit/cb0d9785f2e64c3432568d61ac0d9eefb58c4463)、[链接2](https://github.com/rustsbi/allwinner-hal/commit/7935059ae4c3b56fcdf10a6f141e7441b43065e4)、[链接3](https://github.com/rustsbi/allwinner-hal/commit/63be638ba8d396b29b754e77cb0347014e59580d)
+- rt: 使用allwinner-hal CCU和PHY结构体重构mctl init代码，[链接](https://github.com/rustsbi/allwinner-hal/commit/e134e1d256a7699ee074cd1c637c5984381e2fee)
+- ccu: 增加DRAM时钟控制单元，[链接](https://github.com/rustsbi/allwinner-hal/commit/2abc257643f09aff608d44f9eae241745be23076)
+- 增加nezha-d1示例项目，[链接](https://github.com/rustsbi/allwinner-hal/commit/747e9b5073448f1bc086290c438372691bce86c1)
+- 增加D1-H/D1s/F133芯片有关的SMHC引脚配置，[链接](https://github.com/rustsbi/allwinner-hal/commit/e9a687731f2a6ad5442571567d70ce3593e2c439)
+- 整理与生成宏trait有关的代码，[链接](https://github.com/rustsbi/allwinner-hal/commit/89f1e6cbf8c2bbbf2904064bdafea27f99e4dd83)
+- 重构项目，使用workspace级别的edition、license和repository设置，将allwinner-hal移动到独立的文件夹中，修复CI问题，[链接1](https://github.com/rustsbi/allwinner-hal/commit/5b983d43d2a597a429ff043041d0649f4df0988b)、[链接2](https://github.com/rustsbi/allwinner-hal/commit/1421703311f45c771b9fbc62b9fdf63afa632633)、[链接3](https://github.com/rustsbi/allwinner-hal/commit/35b0991f1c27be799ebae1fa8a22babe755fb930)
+- uart: 重构模块，复用blocking uart的读写逻辑代码，[链接](https://github.com/rustsbi/allwinner-hal/commit/4d722ba1a719cfcc368f8bf2a27532816a1de6bc)；根据用户手册重新设计uart收发代码，[链接](https://github.com/rustsbi/allwinner-hal/commit/4a80e331dc1eeb3117a507c0d9869d8719b65cf2)；增加切分serial为TransmitHalf和ReceiveHalf的功能，[链接](https://github.com/rustsbi/allwinner-hal/commit/96699761e1073ab3a0734b809ef17b50f30ca306)
+- 增加默认隐藏的sysctl模块，[链接](https://github.com/rustsbi/allwinner-hal/commit/655d1f79c81915930b41143135ec670289cd57b2)
+- 适配naked_asm!宏，它在rustc nightly 2024-10-07版本引入，[链接](https://github.com/rustsbi/allwinner-hal/commit/5a4b5d3b22114e58ff2028fcae9f5d55a079893b)
+- rfel: 增加rfel模块，可通过USB和全志ROM链接，连接并获取芯片ID。[链接1](https://github.com/rustsbi/allwinner-hal/commit/e43e4481eaad91247f2f67782b223e73904694b0)、[链接2](https://github.com/rustsbi/allwinner-hal/commit/e43e4481eaad91247f2f67782b223e73904694b0)
+
+团队成员吸收和审核了其它社区的开源贡献。
+
+- 由[@liyang8246](https://github.com/liyang8246)贡献的allwinner-hal项目集成测试模块，[链接](https://github.com/rustsbi/allwinner-hal/pull/12)
+- 由[@sevetis](https://github.com/sevetis)贡献的allwinner-hal项目sram大小修复，[链接](https://github.com/rustsbi/allwinner-hal/pull/8)
+
+#### 发行版组
+
+本月发行版组继续维护RustSBI Prototyper项目和依赖包serde-device-tree。发行版组本月和香山Nemu团队建立了合作，适配RustSBI到Nemu模拟器中，以完善香山处理器的软件生态。
+
+- [Refactor: Decoupling device drivers from SBI implementation](https://github.com/rustsbi/prototyper/pull/18)
+- [fix(prototyper): fixed mtime trap context save and restore bug](https://github.com/rustsbi/prototyper/pull/19)
+- [feat: support none sstc environment](https://github.com/rustsbi/prototyper/pull/20)
+- [build(deps): upgrade rustsbi 0.4.0 denpendencies and format code](https://github.com/rustsbi/prototyper/pull/21)
+- [fix(prototyper): delayed printing of dynamic info parsing errors](https://github.com/rustsbi/prototyper/pull/22)
+- [Add support for payload image](https://github.com/rustsbi/prototyper/pull/23)
+- [feat(prototyper): refactoring the extension probe mechanism to support the AMP architecture](https://github.com/rustsbi/prototyper/pull/24)
+- [fix(prototyper): wrong inline asm](https://github.com/rustsbi/prototyper/pull/12)
+- [refactor(prototyper): remove unnecessary hsm status acquisition](https://github.com/rustsbi/prototyper/pull/14)
+
+serde-device-tree依赖包的修复如下。
+
+- [fix: correct memory layout](https://github.com/rustsbi/serde-device-tree/pull/3)
+- [try to fix some strange issue](https://github.com/rustsbi/serde-device-tree/pull/4)
+- [fix: too early drop_on](https://github.com/rustsbi/serde-device-tree/pull/5)
+- [add Node type](https://github.com/rustsbi/serde-device-tree/pull/6)
+- [Add tests & a GitHub workflow to automatically run tests & fix alignment issues](https://github.com/rustsbi/serde-device-tree/pull/7)
+
+#### 大模型组
+
+大模型组统筹团队的GPU算力资源，调研大模型工作的现有进展和发展方向，集中阅读有关论文。
+
+- 编撰RustSBI Agent项目计划，[链接](https://github.com/rustsbi/Agent/blob/main/rfcs/RustSBI%20Agent%E9%A1%B9%E7%9B%AE%E8%AE%A1%E5%88%92_20241014204801.pdf)
+- 精读和翻译RAG综述《Retrieval-Augmented Generation for Large Language Models》，[任潇译文](https://github.com/rustsbi/Agent/blob/main/rfcs/0002-Oct-work-report-by-rx.md)、[张子涵笔记](https://github.com/rustsbi/Agent/blob/main/rfcs/read-notes-by-zzh.pdf)
+- 调研和对比市场已有开源大模型产品，[链接](https://github.com/rustsbi/Agent/blob/main/rfcs/%E5%BC%80%E6%BA%90%E5%A4%A7%E6%A8%A1%E5%9E%8B%E8%B0%83%E7%A0%94%20by%20kjn.pdf)
+
+#### 核心库日常维护
+
+RustSBI 0.4.0版本正式发布。本月团队成员为RustSBI等核心仓库做出的贡献如下。
+
+- 发布RustSBI 0.4.0正式版，[链接](https://github.com/rustsbi/rustsbi/commit/3370a9b636b30a8d4bca2f5f2c54c922191a1f6d)
+- 发布sbi-spec 0.0.8正式版，[链接](https://github.com/rustsbi/rustsbi/commit/0837da8fc325fca23c5ac7423f087e1d4d54783e)；发布正式版之前，发布sbi-spec 0.0.8-rc.1预览版，以供社区测试，[链接](https://github.com/rustsbi/rustsbi/commit/1e08efedcba064cfa6332e37b76a226e0946b670)
+- 为rustsbi补上遗漏的函数，[链接](https://github.com/rustsbi/rustsbi/pull/77)
+- 为rustsbi的ci添加检查签名和Changelog的功能，[链接](https://github.com/rustsbi/rustsbi/pull/78)；优化CI，切分到多个配置文件，[链接](https://github.com/rustsbi/rustsbi/commit/b47ef25c9bd9d727b1c034b1d47b1e2372aa362a)
+- 针对naked_asm宏适配新版本rustc nightly，[链接](https://github.com/rustsbi/rustsbi/commit/fcd072633c204066d5b5c075f3a5d32eae261398)
+- 更新依赖`riscv`到0.12.0，[链接](https://github.com/rustsbi/rustsbi/commit/5dc0450be9bda85e1e2e56448737d2e45da19ba9)
+- spec: 修订遗忘的changelog，[链接](https://github.com/rustsbi/rustsbi/commit/232b3d7b3036eeeb0d7bdb353e7d44f93ca71fb3)
+- 增加遗漏的pmu_snapshot_set_shmem函数，[链接1](https://github.com/rustsbi/rustsbi/commit/19c191d9eb9c3c5cc46381a8203e8f3462e0ce2d)、[链接2](https://github.com/rustsbi/rustsbi/commit/8ebb0fbdc096aebb14e89301241468af12e55d00)、[链接3](https://github.com/rustsbi/rustsbi/pull/77)；针对sbi-rt，修改pmu模块的参数类型，[链接](https://github.com/rustsbi/rustsbi/commit/62ab2e498ca66cdf75ce049c9dbc2f1862874553)；为rustsbi和sbi-rt导出CounterMask符号，[链接](https://github.com/rustsbi/rustsbi/commit/aae21f2f790e8f9ac7b5f5a3ae81632ee8849fa8)；对pmu_snapshot_set_shmem修复文档，[链接](https://github.com/rustsbi/rustsbi/commit/25418e00e53eaec9eec0f930c99e01d68f7a5228)
+- 为Version实现Hash，[链接](https://github.com/rustsbi/rustsbi/commit/a32cfca3fcf2c8ce4a838132deecf30f8237762c)；为Version实现Eq、PartialEq、Ord和PartialOrd，并添加单元测试，[链接](https://github.com/rustsbi/rustsbi/commit/a853e27ca3265fab1c86d1da6d8f6c5fafb18626)
+- 修订SbiRet::failed的文档问题，[链接](https://github.com/rustsbi/rustsbi/commit/30bd94397cd20f0bf320a8f6285fdde433b26b8c)；增强SbiRet结构体使之满足core::result::Result API约定，[链接](https://github.com/rustsbi/rustsbi/commit/f87e9fc2cdb5575d49146fd3b5b25dc0d279236c)
+- 为Forward结构体生成Copy，Default，PartialEq和Eq，[链接](https://github.com/rustsbi/rustsbi/commit/37d17da97485a7f6d37b0169cc4c644acb26d2c2)
+
+审核和评论了各社区成员为核心库做出的贡献如下。
+
+- [feat: add some config flags with bitflags in chapter 11](https://github.com/rustsbi/rustsbi/pull/74)
+- [sbi-spec: CounterMask missing from binary module](https://github.com/rustsbi/rustsbi/issues/75)
+- [Update README, CHANGELOG for next publishing](https://github.com/rustsbi/rustsbi/issues/63)
+- [update dependency spin to 0.9.8](https://github.com/rustsbi/rustsbi-d1/pull/5)
+
+#### 生态库维护
+
+团队为生态库贡献了以下代码。其中，为SyterKit项目贡献的代码如下：
+
+- [[rust] rearrange mctl driver, move clock init into #[entry], code cleanup](https://github.com/YuzukiHD/SyterKit/pull/136)
+- [[rust] fix rust stdio macros not found](https://github.com/YuzukiHD/SyterKit/pull/137)
+- [[board] cli support on 100ask-d1-h, rearrange mctl module (take 2)](https://github.com/YuzukiHD/SyterKit/pull/138)
+- [[ci] more proper name for check types, small fix](https://github.com/YuzukiHD/SyterKit/pull/142)
+- [[lib] merge dev branch into main branch](https://github.com/YuzukiHD/SyterKit/pull/149)
+- [[board] sd/mmc bootloading support for 100ask-d1-h](https://github.com/YuzukiHD/SyterKit/pull/143)
+
+为其它项目贡献了以下修复和更新：
+
+- 为arceos riscv_vcpu子项目适配RustSBI Forward以降低代码量、提高代码容错性，[链接](https://github.com/arceos-hypervisor/riscv_vcpu/pull/8)
+- 为idlercloud/asynclear增加SBI 2.0 DBCN扩展的支持，[链接](https://github.com/idlercloud/asynclear/commit/03c89b00f3fafe562d29a597416cc6e39abd8fc4)
+- 为r9os/r9提供SBI SRST扩展支持以替代legacy扩展，[链接](https://github.com/r9os/r9/commit/4f56ee9e16848f039ae4e921f8eef065782c20db)
+- 为hikami更新rustsbi版本，[链接](https://github.com/Alignof/hikami/pull/59)
+- 为hypercraft更新rustsbi版本，[链接](https://github.com/KuangjuX/hypercraft/pull/4)
+- 为weathered-steel/rustsbi-jh7110更新rustsbi版本，[链接](https://codeberg.org/weathered-steel/rustsbi-jh7110/pulls/43)
+- 重构RISCV-ONLINE代码，[链接](https://github.com/hust-open-atom-club/riscv-online/pull/3)
+- 升级rustsbi/prototyper的依赖包，[链接](https://github.com/rustsbi/prototyper/pull/21)
+- 初始化riscv-cli项目并添加cli disassemble功能，[链接1](https://github.com/Plucky923/riscv-cli/commit/0a97aab71c6fe9647a77d3f75cefb1ec3f9c5769)、[链接2](https://github.com/Plucky923/riscv-cli/commit/3a540216f97eb8bdf92227cd57a069be6ab8237b)
+
+参与审核了各社区对以下生态项目的贡献：
+
+- [arceos: [feat] replace deprecated sbi_rt legacy console operations in riscv](https://github.com/arceos-org/arceos/pull/195)
+- [oreboot: Rust upgrade, commit Cargo.lock](https://github.com/oreboot/oreboot/pull/758)
+- [feat(uart_xilinx): Remove lifetime & add read write function](https://github.com/duskmoon314/uart-rs/pull/21)
+- [stemnic/rustyvisor: build(deps): upgrade rustsbi 0.4.0 dependencies](https://github.com/stemnic/rustyvisor/pull/8)
+- [rustsbi-qemu: build(deps): upgrade rustsbi 0.4.0 dependencies](https://github.com/rustsbi/rustsbi-qemu/pull/62)
+- [hpmicro/rustsbi-hpm: build(deps): upgrade rustsbi 0.4.0 dependencies](https://github.com/hpmicro/rustsbi-hpm/pull/8)
+
+做了以下组会会议和调研：
+
+- 调研龙芯产品，包括CPU、主板的支持情况、指令集和参考价格，[链接](https://github.com/rustsbi/slides/pull/1)
+- RustSBI Agent项目的会议记要，[链接](https://github.com/rustsbi/slides/commit/f8ce6dc704fd615130a7592594470912c358c212)
+- 测试用例任务书，包含测试用例任务的详细说明，可为以后相似代码任务提供参考，[链接](https://github.com/rustsbi/slides/commit/5ff7153891f31aeed43a2246b005b3b6c4248de8)
+
+#### 小队举办和参与的社区活动
+
+小队本月主办的社区活动如下。
+
+- “华中科技大学第一届开源操作系统训练营”活动，邀请清华大学李明老师、RustSBI社区维护者洛佳、DragonOS社区维护者龙进等嘉宾参与演讲。[链接1](https://mp.weixin.qq.com/s/xpJYwYknQ-4Snsa-S3Qedw)，[链接2](https://mp.weixin.qq.com/s/JMy8blbkVo_d66YqznO3Xw)，[讲稿链接](https://github.com/rustsbi/slides/commit/7958b0d9a55c4ce473e4a7a64788bd7c5192ac62)
+- “开源操作系统训练营——华科线下沙龙”活动，分享Rust语言与RustSBI社区日常工作，带领同学参观RustSBI团队的工作场所。[链接](https://mp.weixin.qq.com/s/ylQg_u2iLT6EdVZ5u3gNCQ)
+
+此外，小队成员参与了其它社区的开源活动。
+
+- 受邀参与“GOSIM开源创新汇”作演讲《Let's try out RustSBI》，会上发布RustSBI 0.4.0新版本，担任嵌入式Rust会场主持人，[讲稿链接](https://github.com/rustsbi/slides/blob/main/2024/GOSIM-Luo%20Jia%2C%20Qing%20Dong-Let's%20Try%20Out%20RustSBI.pdf)、[视频链接](https://mp.weixin.qq.com/s?__biz=MzkxMzUzMzIxMw==&mid=2247485407&idx=1&sn=35507fa12b033bb093c1a7f909d57a9a&chksm=c024e9081f1263e336441d55107f112e2e45cfb6ee69186fcbd1cfdd8d7c29e9934cc0d1d4aa)；撰写了GOSIM演讲见闻，[链接](https://mp.weixin.qq.com/s?__biz=MzkxMzUzMzIxMw==&mid=2247485407&idx=1&sn=35507fa12b033bb093c1a7f909d57a9a&chksm=c024e9081f1263e336441d55107f112e2e45cfb6ee69186fcbd1cfdd8d7c29e9934cc0d1d4aa)
+- 受邀参与“河南大学开源操作系统夏令营第一次线上分享会”并发表演讲，[链接](https://www.bilibili.com/video/BV15XmuYLEQ2)
+- 带队参加“Linux中国大会”，带领同学们参加体系架构与虚拟化分会场，了解RISCV虚拟化；为现场所有活动参与者准备RustSBI团队的贴纸周边，并在现场与龙芯、字节等团队交流，并与龙芯团队初步达成了合作关系
+
 ### J129 RISC-V开发板软件生态联合观测实习生【甲辰计划联合实习生培养】
 
 ### J128 deepin 操作系统开发实习生（RISC-V架构）【甲辰计划联合实习生培养】

--- a/reports/2024-10.md
+++ b/reports/2024-10.md
@@ -159,11 +159,12 @@ RustSBI 0.4.0版本正式发布。本月团队成员为RustSBI等核心仓库做
 - “华中科技大学第一届开源操作系统训练营”活动，邀请清华大学李明老师、RustSBI社区维护者洛佳、DragonOS社区维护者龙进等嘉宾参与演讲。[链接1](https://mp.weixin.qq.com/s/xpJYwYknQ-4Snsa-S3Qedw)，[链接2](https://mp.weixin.qq.com/s/JMy8blbkVo_d66YqznO3Xw)，[讲稿链接](https://github.com/rustsbi/slides/commit/7958b0d9a55c4ce473e4a7a64788bd7c5192ac62)
 - “开源操作系统训练营——华科线下沙龙”活动，分享Rust语言与RustSBI社区日常工作，带领同学参观RustSBI团队的工作场所。[链接](https://mp.weixin.qq.com/s/ylQg_u2iLT6EdVZ5u3gNCQ)
 
-此外，小队成员参与了其它社区的开源活动。
+此外，小队成员参与了各个相关社区的开源活动。
 
 - 受邀参与“GOSIM开源创新汇”作演讲《Let's try out RustSBI》，会上发布RustSBI 0.4.0新版本，担任嵌入式Rust会场主持人，[讲稿链接](https://github.com/rustsbi/slides/blob/main/2024/GOSIM-Luo%20Jia%2C%20Qing%20Dong-Let's%20Try%20Out%20RustSBI.pdf)、[视频链接](https://mp.weixin.qq.com/s?__biz=MzkxMzUzMzIxMw==&mid=2247485407&idx=1&sn=35507fa12b033bb093c1a7f909d57a9a&chksm=c024e9081f1263e336441d55107f112e2e45cfb6ee69186fcbd1cfdd8d7c29e9934cc0d1d4aa)；撰写了GOSIM演讲见闻，[链接](https://mp.weixin.qq.com/s?__biz=MzkxMzUzMzIxMw==&mid=2247485407&idx=1&sn=35507fa12b033bb093c1a7f909d57a9a&chksm=c024e9081f1263e336441d55107f112e2e45cfb6ee69186fcbd1cfdd8d7c29e9934cc0d1d4aa)
 - 受邀参与“河南大学开源操作系统夏令营第一次线上分享会”并发表演讲，[链接](https://www.bilibili.com/video/BV15XmuYLEQ2)
 - 带队参加“Linux中国大会”，带领同学们参加体系架构与虚拟化分会场，了解RISCV虚拟化；为现场所有活动参与者准备RustSBI团队的贴纸周边，并在现场与龙芯、字节等团队交流，并与龙芯团队初步达成了合作关系
+- 在RISC-V Open Hours和东亚时区RISC-V双周会上每两周汇报团队进展
 
 ### J129 RISC-V开发板软件生态联合观测实习生【甲辰计划联合实习生培养】
 


### PR DESCRIPTION
On October 2024, our RustSBI team have totally 114 contributions, including 90 code commits, 12 reviews for contibutors on other open source communities, 7 documents and meeting minutes, 5 offline meetings hosted, given speech to or joined.

[Rendered](https://github.com/luojia65/jiachen-monthly/blob/rustsbi-2024-10/reports/2024-10.md#j130-bl808-rust%E6%94%AF%E6%8C%81%E5%BA%93%E5%BC%80%E5%8F%91%E5%AE%9E%E4%B9%A0%E7%94%9F%E7%94%B2%E8%BE%B0%E8%AE%A1%E5%88%92%E8%81%94%E5%90%88%E5%AE%9E%E4%B9%A0%E7%94%9F%E5%9F%B9%E5%85%BB)

r? @lazyparser 