### PR TITLE
Add contribution for RuyiSDK website

### DIFF
--- a/reports/2025-05.md
+++ b/reports/2025-05.md
@@ -120,6 +120,8 @@ Monthly update of Jiachen Joint Open Source Internship Program
 __apr3vau__ :
 - https://github.com/ruyisdk/support-matrix/pull/309
   测试 Premier P550 和 Megrez 开发板对deepin操作系统及ruyisdk的支持，撰写报告及安装指南
+- https://github.com/ruyisdk/ruyisdk-website/pull/129
+  帮助RuyiSDK修复网站页面排版问题，并使用git submodule管理双周报。由于对方原因尚未合并
 
 ### J127 香山笔记本电脑研发实习生（嵌入式基础软件开发方向）【甲辰计划联合实习生培养】
 


### PR DESCRIPTION
修复网站外观，使用git submodule管理双周报，但由于双周报repo暂时缺乏元数据，上游数据缺失，因此尚未合并。